### PR TITLE
WIP: add run_test parameters to context

### DIFF
--- a/podder_task_base/api/task_api_executor.py
+++ b/podder_task_base/api/task_api_executor.py
@@ -11,7 +11,7 @@ class TaskApiExecutor(object):
     def execute(self, request, _context):
         settings.init()
         dag_id = request.dag_id
-        context = Context(dag_id)
+        context = Context(dag_id, _context.run_test)
         inputs = self._convert_to_input_data(request)
         outputs = self.execution_task(context).execute(inputs)
         task_response = self._convert_to_task_response(dag_id, outputs)

--- a/podder_task_base/context.py
+++ b/podder_task_base/context.py
@@ -6,9 +6,10 @@ from .logger import Logger
 
 
 class Context(object):
-    def __init__(self, dag_id: str) -> None:
+    def __init__(self, dag_id: str, run_test: bool) -> None:
         self.logger = Logger()
         self.config = Config()
         self.file = File()
         self.session = PipelineSession()
         self.dag_id = dag_id
+        self.run_test = run_test


### PR DESCRIPTION
### 目的
結合テストのとき sensor-task、writer-task で実行履歴を保存しないようにする

### 詳細
contextにrun_testのフラグを持たせる

### 質問
`podder-task-base` を修正する必要があるとき、どのようにテストを行なっていますか？
pipelineとtaskのcontextが異なるので、一度podder-task-baseの修正をマージしてpypyにあげる必要があると思っているのですが、動作確認まえにマージするのは良くないなと思い。