### PR TITLE
Jinja2 / SQLAlchemy version up for security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ grpcio-tools==1.18.0
 googleapis-common-protos==1.5.6
 python-daemon==2.2.0
 mysqlclient==1.4.1
-SQLAlchemy==1.2.17
+SQLAlchemy==1.2.19
 python-dotenv==0.10.1
 click==6.7
-jinja2==2.10
+jinja2==2.10.1
 PyYAML==5.1
 pytest==4.3.1
 requests==2.21.0


### PR DESCRIPTION
Jinja2 2.10 -> 2.10.1 ( Ref: https://www.cvedetails.com/cve/CVE-2019-8341/ )
SQLAlchemy 1.2.17 -> 1.2.19 ( https://www.cvedetails.com/cve/CVE-2019-7548/ )
