### PR TITLE
feature/PA811/change_pipeline_arg_to_file

### DIFF
--- a/podder_task_base/api/task_api_executor.py
+++ b/podder_task_base/api/task_api_executor.py
@@ -1,5 +1,7 @@
+from typing import Tuple
 import json
 import traceback
+from pathlib import Path
 
 from podder_task_base import Context, settings
 from podder_task_base.log import logger
@@ -17,9 +19,11 @@ class TaskApiExecutor(object):
         context = Context(dag_id)
 
         try:
-            inputs = self._convert_to_input_data(request)
+            inputs, job_id, task_name = self._parse_request_and_load_arg_file(request)
             outputs = self.execution_task(context).execute(inputs)
-            task_response = self._convert_to_task_response(dag_id, outputs)
+            task_response = self._generate_arg_file_and_convert_to_task_response(
+                dag_id, job_id, task_name, outputs)
+
         except Exception:
             self.logger.error(traceback.format_exc())
             return self._make_error_task_response(dag_id)
@@ -27,18 +31,36 @@ class TaskApiExecutor(object):
         return task_response
 
     @staticmethod
-    def _convert_to_input_data(request):
+    def _parse_request_and_load_arg_file(request) -> Tuple[list, str]:
         inputs = []
+        job_id = None
         for result in request.results:
-            inputs.append({'job_id': result.job_id, 'job_data': json.loads(result.job_data)})
-        return inputs
+            job_id = result.job_id
+            job_data = json.loads(result.job_data)
+            task_name = job_data['task_name']
 
-    def _convert_to_task_response(self, dag_id: str, outputs):
+            arg_file = Path(job_data['arg_file'])
+            with arg_file.open() as file:
+                arg_data = json.loads(file.read())
+
+            inputs.append({'job_id': job_id, 'job_data': arg_data})
+        return inputs, job_id, task_name
+
+    def _generate_arg_file_and_convert_to_task_response(self,
+                                                        dag_id: str,
+                                                        job_id: str,
+                                                        task_name: str,
+                                                        outputs):
         task_response = self.gprc_pb2.TaskResponse()
         task_response.dag_id = dag_id
-        for output in outputs:
+        for i, output in enumerate(outputs):
+            arg_file = Path('/usr/local/poc_base/tmp/{}/{}/arg/{}_{}.json'.format(
+                dag_id, job_id, task_name, i))
+            with arg_file.open('w') as file:
+                file.write(json.dumps(output['job_data']))
+
             task_response.results.add(job_id=output['job_id'],
-                                      job_data=json.dumps(output['job_data']))
+                                      job_data=json.dumps({'arg_file': str(arg_file)}))
         return task_response
 
     def _make_error_task_response(self, dag_id):

--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -43,6 +43,9 @@ class Logger(object):
         # trace -> notset(python logger)
         self.logger.log(logging.NOTSET, msg, extra=self._create_extra(), *args, **kwargs)
 
+    def log(self, msg, *args, **kwargs):
+        self.logger.log(msg, extra=self._create_extra(), *args, **kwargs)
+
     # private
     def _create_extra(self):
         ex = {'progresstime': str(round((time.time() - self.start_time), 3)),


### PR DESCRIPTION
https://nexusfrontiertech.atlassian.net/browse/PA-811
pipelineのデータ受け渡しをtmp内にファイルを作る形で修正しました。

https://github.com/podder-ai/podder-pipeline/pull/78
このプルリクエストとセットになっています。

```
・実装仕様
podder-pipeline, podder-task-baseで処理を吸収する

tmp/[dag_id]/[job_id]/arg/
フォルダに受け渡しデータのファイルを配置する

実際にタスクに引き渡すデータの形式は、jsonとする

podder-pipelineでは、引数として受け渡すファイルのパスを次のタスクに渡す
最初のタスクのための受け渡しデータのファイルは、podder-pipelineで作成する
tmp/[dag_id]/[job_id]/arg/pipeline.json

podder-task-baseで、input部分の処理用のサービスクラス、output処理用のサービスクラスを用意し、
ファイル生成とpodder-pipelineへの受け渡し用ファイルパスの受け渡しを行う
tmp/[dag_id]/[job_id]/arg/[タスク名].json (仮)

なお、outputが空の場合、最後のタスクの場合は、ファイルは作成しない。

podder-pipelineと各タスクのデータ渡し（grpcのjob_dataの中身）は以下のような形式にする。
{'arg_file': '[file_path]'}
```