### PR TITLE
PA-851 replace newline character

### DIFF
--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -24,27 +24,27 @@ class Logger(object):
 
     def fatal(self, msg, *args, **kwargs):
         # fatal -> critical(python logger)
-        self.logger.critical(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.CRITICAL, msg, *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self.logger.error(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.ERROR, msg, *args, **kwargs)
 
     def warn(self, msg, *args, **kwargs):
         # warn -> warning(python logger)
-        self.logger.warning(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.WARNING, msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        self.logger.info(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.INFO, msg, *args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        self.logger.debug(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.DEBUG, msg, *args, **kwargs)
 
     def trace(self, msg, *args, **kwargs):
         # trace -> notset(python logger)
-        self.logger.log(logging.NOTSET, self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.NOTSET, msg, *args, **kwargs)
 
     def log(self, msg, *args, **kwargs):
-        self.logger.log(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
+        self._log(logging.NOTSET, msg, *args, **kwargs)
 
     # private
     def _create_extra(self):
@@ -66,13 +66,18 @@ class Logger(object):
         handler.setFormatter(logging.Formatter(fmt=log_format, datefmt='%Y-%m-%d %H:%M:%S'))
         self.logger.addHandler(handler)
 
-    def _convert_newline_character(self, message):
+    def _convert_newline_character(self, msg):
         old_character =  '\n'
         new_character = '\\n'
-        if old_character in message:
-            return message.replace(old_character, new_character)
+        if old_character in msg:
+            return msg.replace(old_character, new_character)
         else:
-            return message
+            return msg
+
+    def _log(self, lvl, msg, *args, **kwargs):
+        self.logger.setLevel(lvl)
+        self.logger.log(lvl, self._convert_newline_character(msg),  extra=self._create_extra(), *args, **kwargs)
+
 
 
 def class_logger(cls):

--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -72,9 +72,7 @@ class Logger(object):
         return msg.replace(old_character, new_character)
 
     def _format(self, lvl, msg, *args, **kwargs):
-        self.logger.setLevel(lvl)
         self.logger.log(lvl, self._convert_newline_character(msg),  extra=self._create_extra(), *args, **kwargs)
-
 
 
 def class_logger(cls):

--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -24,27 +24,27 @@ class Logger(object):
 
     def fatal(self, msg, *args, **kwargs):
         # fatal -> critical(python logger)
-        self.logger.critical(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.critical(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self.logger.error(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.error(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def warn(self, msg, *args, **kwargs):
         # warn -> warning(python logger)
-        self.logger.warning(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.warning(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        self.logger.info(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.info(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        self.logger.debug(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.debug(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def trace(self, msg, *args, **kwargs):
         # trace -> notset(python logger)
-        self.logger.log(logging.NOTSET, msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.log(logging.NOTSET, self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     def log(self, msg, *args, **kwargs):
-        self.logger.log(msg, extra=self._create_extra(), *args, **kwargs)
+        self.logger.log(self._convert_newline_character(msg), extra=self._create_extra(), *args, **kwargs)
 
     # private
     def _create_extra(self):
@@ -65,6 +65,14 @@ class Logger(object):
         handler.setLevel(log_level)
         handler.setFormatter(logging.Formatter(fmt=log_format, datefmt='%Y-%m-%d %H:%M:%S'))
         self.logger.addHandler(handler)
+
+    def _convert_newline_character(self, message):
+        old_character =  '\n'
+        new_character = '\\n'
+        if old_character in message:
+            return message.replace(old_character, new_character)
+        else:
+            return meddage
 
 
 def class_logger(cls):

--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -24,27 +24,27 @@ class Logger(object):
 
     def fatal(self, msg, *args, **kwargs):
         # fatal -> critical(python logger)
-        self._log(logging.CRITICAL, msg, *args, **kwargs)
+        self._format(logging.CRITICAL, msg, *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self._log(logging.ERROR, msg, *args, **kwargs)
+        self._format(logging.ERROR, msg, *args, **kwargs)
 
     def warn(self, msg, *args, **kwargs):
         # warn -> warning(python logger)
-        self._log(logging.WARNING, msg, *args, **kwargs)
+        self._format(logging.WARNING, msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        self._log(logging.INFO, msg, *args, **kwargs)
+        self._format(logging.INFO, msg, *args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        self._log(logging.DEBUG, msg, *args, **kwargs)
+        self._format(logging.DEBUG, msg, *args, **kwargs)
 
     def trace(self, msg, *args, **kwargs):
         # trace -> notset(python logger)
-        self._log(logging.NOTSET, msg, *args, **kwargs)
+        self._format(logging.NOTSET, msg, *args, **kwargs)
 
     def log(self, msg, *args, **kwargs):
-        self._log(logging.NOTSET, msg, *args, **kwargs)
+        self._format(logging.NOTSET, msg, *args, **kwargs)
 
     # private
     def _create_extra(self):
@@ -69,12 +69,9 @@ class Logger(object):
     def _convert_newline_character(self, msg):
         old_character =  '\n'
         new_character = '\\n'
-        if old_character in msg:
-            return msg.replace(old_character, new_character)
-        else:
-            return msg
+        return msg.replace(old_character, new_character)
 
-    def _log(self, lvl, msg, *args, **kwargs):
+    def _format(self, lvl, msg, *args, **kwargs):
         self.logger.setLevel(lvl)
         self.logger.log(lvl, self._convert_newline_character(msg),  extra=self._create_extra(), *args, **kwargs)
 

--- a/podder_task_base/log/logger.py
+++ b/podder_task_base/log/logger.py
@@ -72,7 +72,7 @@ class Logger(object):
         if old_character in message:
             return message.replace(old_character, new_character)
         else:
-            return meddage
+            return message
 
 
 def class_logger(cls):

--- a/tests/unit/log/test_logger.py
+++ b/tests/unit/log/test_logger.py
@@ -1,0 +1,49 @@
+from podder_task_base.log.logger import Logger
+
+class TestLogger:
+
+    def test_convert_newline_character_without_newline(self):
+        message = Logger()._convert_newline_character("log message")
+        assert message == "log message"
+
+    def test_convert_newline_character_with_newline(self):
+        message = Logger()._convert_newline_character("log\nmessage\n")
+        assert message == "log\\nmessage\\n"
+   
+    def test_fatal(self, capsys):
+        Logger().fatal("fatal log")
+        stdout, stderr = capsys.readouterr()
+        assert "fatal log" in stdout
+        assert "CRITICAL" in stdout   
+
+    def test_error(self, capsys):
+        Logger().error("error log")
+        stdout, stderr = capsys.readouterr()
+        assert "error log" in stdout
+        assert "ERROR" in stdout  
+
+    def test_warn(self, capsys):
+        Logger().warn("warn log")
+        stdout, stderr = capsys.readouterr()
+        assert "warn log" in stdout
+        assert "WARNING" in stdout 
+
+    def test_info(self, capsys):
+        Logger().info("info log")
+        stdout, stderr = capsys.readouterr()
+        assert "info log" in stdout
+        assert "INFO" in stdout 
+
+    def test_debug(self, capsys):
+        Logger().debug("debug log")
+        stdout, stderr = capsys.readouterr()
+        assert "debug log" in stdout
+        assert "DEBUG" in stdout
+
+    def test_trace(self):
+        Logger().trace("trace log")
+        pass
+
+    def test_log(self, capsys):
+        Logger().log("log")
+        pass


### PR DESCRIPTION
https://nexusfrontiertech.atlassian.net/browse/PA-851

背景
  Podderタスクが生成したログに改行が入っていて、Fluentdで収集すると、キレイに1レコードとして判断できないのです。
  Fluentdにうまく複数行の対応ができたら、必要ですが、すぐ解決できなさそうなのです。

やりたいこと
  Loggerクラスで改行があったら、 \n などに変換する