### PR TITLE
feature/PA-2498-improve-stopping-of-task

### DIFF
--- a/podder_task_base/api/grpc_server.py
+++ b/podder_task_base/api/grpc_server.py
@@ -21,7 +21,7 @@ class GrpcServer(object):
         max_requests = int(self.max_rpcs_requests) if self.max_rpcs_requests else None
 
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=int(self.max_workers)),
-                                                        maximum_concurrent_rpcs=max_requests)
+                             maximum_concurrent_rpcs=max_requests)
         self.add_servicer_to_server(self.task_api_class(self.execution_task), server)
         server.add_insecure_port('[::]:' + str(self.port))
 

--- a/podder_task_base/api/grpc_server.py
+++ b/podder_task_base/api/grpc_server.py
@@ -1,4 +1,5 @@
 import time
+import signal
 from concurrent import futures
 from typing import Any, Optional
 import grpc
@@ -29,6 +30,12 @@ class GrpcServer(object):
 
         print("[{}] gRPC server is listening to port: '[::]:{}'".format(
             time.strftime("%Y-%m-%d %H:%m:%S"), self.port))
+
+        # stop gRPC server when SIGTERM signal received
+        def sigterm_handler(signum, frame):
+            server.stop(0)
+        signal.signal(signal.SIGTERM, sigterm_handler)
+
         try:
             server.wait_for_termination()
         except KeyboardInterrupt:

--- a/podder_task_base/api/grpc_server.py
+++ b/podder_task_base/api/grpc_server.py
@@ -1,21 +1,15 @@
 import time
 from concurrent import futures
 from typing import Any, Optional
-
-import daemon
 import grpc
-from daemon import pidfile
 
 
 class GrpcServer(object):
-    _ONE_DAY_IN_SECONDS = 60 * 60 * 24
-
-    def __init__(self, stdout_file: str, stderr_file: str, pidfile_path: str, execution_task: Any,
+    def __init__(self, stdout_file: str, stderr_file: str, execution_task: Any,
                  max_workers: int, max_rpcs_requests: Optional[str],
                  port: int, add_servicer_method: Any, task_api_class: Any):
         self.stdout_file = stdout_file
         self.stderr_file = stderr_file
-        self.pidfile_path = pidfile_path
         self.execution_task = execution_task
         self.max_workers = max_workers
         self.max_rpcs_requests = max_rpcs_requests
@@ -24,30 +18,19 @@ class GrpcServer(object):
         self.task_api_class = task_api_class
 
     def run(self):
-        """
-        Run gRPC server with new daemon process.
-        """
-        pid_lock_file = pidfile.PIDLockFile(self.pidfile_path)
-        with daemon.DaemonContext(stdout=self.stdout_file,
-                                  stderr=self.stderr_file,
-                                  pidfile=pid_lock_file,
-                                  detach_process=True):
-            self.serve()
+        max_requests = int(self.max_rpcs_requests) if self.max_rpcs_requests else None
 
-    def serve(self):
-        if self.max_rpcs_requests:
-            max_requests = int(self.max_rpcs_requests)
-        else:
-            max_requests = None
-        server = grpc.server(futures.ThreadPoolExecutor(max_workers=int(self.max_workers)), maximum_concurrent_rpcs=max_requests)
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=int(self.max_workers)),
+                                                        maximum_concurrent_rpcs=max_requests)
         self.add_servicer_to_server(self.task_api_class(self.execution_task), server)
         server.add_insecure_port('[::]:' + str(self.port))
 
         server.start()
+
         print("[{}] gRPC server is listening to port: '[::]:{}'".format(
             time.strftime("%Y-%m-%d %H:%m:%S"), self.port))
         try:
-            while True:
-                time.sleep(self._ONE_DAY_IN_SECONDS)
+            server.wait_for_termination()
         except KeyboardInterrupt:
-            server.stop(0)
+            pass
+        server.stop(0)

--- a/podder_task_base/api/grpc_server.py
+++ b/podder_task_base/api/grpc_server.py
@@ -32,5 +32,5 @@ class GrpcServer(object):
         try:
             server.wait_for_termination()
         except KeyboardInterrupt:
-            pass
-        server.stop(0)
+            server.stop(0)
+

--- a/podder_task_base/api/grpc_server.py
+++ b/podder_task_base/api/grpc_server.py
@@ -33,11 +33,14 @@ class GrpcServer(object):
 
         # stop gRPC server when SIGTERM signal received
         def sigterm_handler(signum, frame):
+            print("SIGTERM received.")
             server.stop(0)
         signal.signal(signal.SIGTERM, sigterm_handler)
 
         try:
             server.wait_for_termination()
         except KeyboardInterrupt:
+            print("SIGINT received.")
             server.stop(0)
 
+        print("stopped gRPC server.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 grpcio-tools==1.18.0
 googleapis-common-protos==1.6.0
-python-daemon==2.2.0
 mysqlclient==1.4.1
 SQLAlchemy==1.3.3
 python-dotenv==0.10.1


### PR DESCRIPTION
対応内容
* daemonを削除
* gRPCサーバが起動中の状態で待つ処理を、 `server.wait_for_termination()` を使うように変更
* `SIGTERM` のシグナルを受け取れるようにハンドラを作成