### PR TITLE
set pool_size, max_overflow based on `GRPC_MAX_WORKERS` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+# [Unrelease]
+### Changed
+- [PA-2516] Setting Mysql session pool_size, max_overflow using `GRPC_MAX_WORKERS` from settings
+
 ## [0.8.0]
 ### Changes
 - [PA-2498] Change to stop grpc_server.py when SIGTERM signal received.

--- a/podder_task_base/databases/pipeline.py
+++ b/podder_task_base/databases/pipeline.py
@@ -1,4 +1,4 @@
-from podder_task_base.settings import PIPELINE_DATABASE_URL, PIPELINE_READ_ONLY_DATABASE_URL
+from podder_task_base.settings import PIPELINE_DATABASE_URL, PIPELINE_READ_ONLY_DATABASE_URL, GRPC_MAX_WORKERS
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -8,17 +8,26 @@ from typing import Optional
 from .sqlalchemy_logger_setting import SqlalchemyLoggerSetting
 
 if PIPELINE_DATABASE_URL is not None:
-    engine: Engine = create_engine(PIPELINE_DATABASE_URL, echo=False)
+    engine: Engine = create_engine(PIPELINE_DATABASE_URL,
+                                   echo=False,
+                                   pool_size=GRPC_MAX_WORKERS + 1,
+                                   max_overflow=GRPC_MAX_WORKERS + 1)
     Session: Optional[DeclarativeMeta] = sessionmaker(bind=engine)
     SqlalchemyLoggerSetting()
 else:
     Session: Optional[DeclarativeMeta] = None
 
 if PIPELINE_READ_ONLY_DATABASE_URL:
-    read_only_engine: Engine = create_engine(PIPELINE_READ_ONLY_DATABASE_URL, echo=False)
+    read_only_engine: Engine = create_engine(PIPELINE_READ_ONLY_DATABASE_URL,
+                                             echo=False,
+                                             pool_size=GRPC_MAX_WORKERS + 1,
+                                             max_overflow=GRPC_MAX_WORKERS + 1)
     ReadOnlySession: Optional[DeclarativeMeta] = sessionmaker(bind=read_only_engine)
 elif PIPELINE_DATABASE_URL:
-    read_only_engine: Engine = create_engine(PIPELINE_DATABASE_URL, echo=False)
+    read_only_engine: Engine = create_engine(PIPELINE_DATABASE_URL,
+                                             echo=False,
+                                             pool_size=GRPC_MAX_WORKERS + 1,
+                                             max_overflow=GRPC_MAX_WORKERS + 1)
     ReadOnlySession: Optional[DeclarativeMeta] = sessionmaker(bind=read_only_engine)
 else:
     ReadOnlySession: Optional[DeclarativeMeta] = None

--- a/podder_task_base/settings.py
+++ b/podder_task_base/settings.py
@@ -8,11 +8,12 @@ def init() -> None:
     load_dotenv()
 
 
-def get(key: str) -> Optional[str]:
-    return os.getenv(key)
+def get(key: str, default = None) -> Optional[str]:
+    return os.getenv(key, default)
 
 
 # Shortcut variables for Framework.
 PIPELINE_DATABASE_URL = get('PIPELINE_DATABASE_URL')
 PIPELINE_READ_ONLY_DATABASE_URL = get('PIPELINE_READ_ONLY_DATABASE_URL')
 GOOGLE_STORAGE_BUCKET = get('GOOGLE_STORAGE_BUCKET')
+GRPC_MAX_WORKERS = int(get('GRPC_MAX_WORKERS', 10))


### PR DESCRIPTION
https://nexusfrontiertech.atlassian.net/browse/PA-2516
MYSQL Alchemyのエラーを対応しました。
TimeoutError: QueuePool limit of size 5 overflow 10 reached

api-writer-taskの実装で他に一つMYSQLセッションをはるところがあるので、修正しました。
https://github.com/podder-ai/cinnamon-podder-saas/blob/cinnamon-without-airflow/api-writer-task/app/writer.py#L186

Worker確認環境でエラーが出なくなったことが確認できました。